### PR TITLE
Fix server startup & Escape filename from godot

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,17 +7,24 @@ term_exec="wezterm"
 nvim_exec="nvim"
 # - replace with other path for the Neovim server pipe
 server_path="$HOME/.cache/nvim/godot-server.pipe"
+# - if you don't get the gdscript in nvim on startup increase this number NOTE: delay is in seconds
+server_startup_delay=0.1
 
 start_server() {
-    "$term_exec" -e "$nvim_exec" --listen "$server_path" "$1"
+    "$term_exec" -e "$nvim_exec" --listen "$server_path"
 }
 
 open_file_in_server() {
-    "$term_exec" -e "$nvim_exec" --server "$server_path" --remote-send "<C-\><C-n>:n $1<CR>:call cursor($2)<CR>"
+    # - escape stuff because nvim will not
+    filename=$(printf %q "$1")
+    "$term_exec" -e "$nvim_exec" --server "$server_path" --remote-send "<C-\><C-n>:n $filename<CR>:call cursor($2)<CR>"
 }
 
 if ! [ -e "$server_path" ]; then
-    start_server "$1"
-else 
+    # - start server FIRST then open the file
+    start_server &
+    sleep $server_startup_delay # - wait for the server to start 
+    open_file_in_server "$1" "$2"
+else
     open_file_in_server "$1" "$2"
 fi


### PR DESCRIPTION
Almost the same script i posted in #1 but i made better mainly because sleep in that issue was giving a error instead of actually sleeping which on my machine was enough time for the server to startup normally most of the time 

Fixes #1 

Sorry for the delay, but better late than never